### PR TITLE
Bug fixes: measured_srate and int64 string matching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xdf"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ use crate::parsers::xdf_file::xdf_file_parser;
 type StreamID = u32;
 type SampleIter = std::vec::IntoIter<Sample>;
 
-/// XDF file struct  
+/// XDF file struct
 /// The main struct representing an XDF file.
 #[derive(Debug, Clone, PartialEq)]
 pub struct XDFFile {
@@ -69,7 +69,6 @@ pub struct XDFFile {
     pub version: f32,
     /// The XML header of the XDF file as an [`xmltree::Element`].
     pub header: xmltree::Element,
-
     /// A vector of streams contained in the XDF file.
     pub streams: Vec<Stream>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,13 +291,12 @@ fn process_streams(mut grouped_chunks: GroupedChunks) -> Result<Vec<Stream>, XDF
             let first_timestamp: Option<f64> = samples_vec.first().and_then(|s| s.timestamp);
             let last_timestamp: Option<f64> = samples_vec.last().and_then(|s| s.timestamp);
 
-            if let (num_samples, Some(first_timestamp), Some(last_timestamp)) =
-                (samples_vec.len(), first_timestamp, last_timestamp)
-            {
-                if num_samples == 0 {
+            if let (Some(first_timestamp), Some(last_timestamp)) = (first_timestamp, last_timestamp) {
+                let delta = last_timestamp - first_timestamp;
+                if delta <= 0.0 || !delta.is_finite() {
                     None // don't divide by zero :)
                 } else {
-                    Some((last_timestamp - first_timestamp) / num_samples as f64)
+                    Some(samples_vec.len() as f64 / delta)
                 }
             } else {
                 None

--- a/src/parsers/stream_header.rs
+++ b/src/parsers/stream_header.rs
@@ -13,6 +13,7 @@ fn str_to_format(input: &str) -> Option<Format> {
         "int8" => Some(Format::Int8),
         "int16" => Some(Format::Int16),
         "int32" => Some(Format::Int32),
+        "int64" => Some(Format::Int64),
         "float32" => Some(Format::Float32),
         "double64" => Some(Format::Float64),
         "string" => Some(Format::String),


### PR DESCRIPTION
Bugs:
- measured_srate was calculated incorrectly
- "int64" was missing from the Format match statement, so any int64 chunks would lead to an error